### PR TITLE
Updated the Jekyll theme version (3.9.4) - fix for bootstrap-sass vuln

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # Jumbo Jekyll Theme 
-gem 'jumbo-jekyll-theme', "3.3"
+gem 'jumbo-jekyll-theme', "3.9.4"
 # Jekyll Plugins
 group :jekyll_plugins do
    gem "jekyll-data"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,11 +3,11 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    autoprefixer-rails (9.4.4)
+    autoprefixer-rails (9.4.9)
       execjs
-    bootstrap-sass (3.3.7)
+    bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
-      sass (>= 3.3.4)
+      sassc (>= 2.0.0)
     colorator (1.1.0)
     concurrent-ruby (1.0.5)
     em-websocket (0.5.1)
@@ -78,9 +78,9 @@ GEM
       jekyll
     jekyll-watch (2.1.2)
       listen (~> 3.0)
-    jumbo-jekyll-theme (3.3)
+    jumbo-jekyll-theme (3.9.4)
       autoprefixer-rails (~> 9.0, >= 9.0.0)
-      bootstrap-sass (~> 3.3.6)
+      bootstrap-sass (~> 3.4.1)
       ffi (~> 1.9.24)
       hash-joiner (~> 0)
       jekyll (~> 3.7.4)
@@ -114,6 +114,7 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (3.0.3)
     rack (1.6.11)
+    rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -126,6 +127,9 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -139,8 +143,8 @@ DEPENDENCIES
   jekyll-data
   jekyll-include-cache
   jekyll-responsive-image
-  jumbo-jekyll-theme (= 3.3)
+  jumbo-jekyll-theme (= 3.9.4)
   nokogiri
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/assets/css/app/overrides.scss
+++ b/assets/css/app/overrides.scss
@@ -11,8 +11,12 @@ $sub-footer-color: #000;
 // Navbar
 $navbar-text-color: #fff;
 $navbar-height: 66px;
+$navbar-hover-text-color: #fff !default;
+$navbar-hover-background-color: $brand-primary !default;
 $navbar-inverse-bg: #000;
 $navbar-inverse-color: #fff;
+$navbar-submenu-bg-color: #3e3e3e !default;
+$navbar-submenu-color: #fff !default;
 @font-face {
   font-family: 'Lato';
   src: url('/assets/fonts/lato-regular/Lato-regular.eot'); /* IE9 Compat Modes */
@@ -36,3 +40,15 @@ $jumbotron-heading-color: #fff !default;
 $jumbotron-sub-title-font-size-xs: 16px;
 $jumbotron-sub-title-font-size: 18px;
 $jumbotron-sub-title-color: #fff !default;
+// Tabbed Navbar
+$tabbed-nav-bg-color: #f5f5f5 !default;
+$tabbed-nav-text-color: #262626 !default;
+$tabbed-nav-hover-color: $brand-primary !default;
+// Post tags
+$post-tag-bg: #d7d7d7 !default;
+$post-tag-color: #000 !default;
+$post-tag-border: #8b8b8b !default;
+$post-tag-hover-bg: #1f1f1f !default;
+$post-tag-hover-color: #fff !default;
+// Triangle Divider
+$triangle-divider-bg-color: #fff !default;  


### PR DESCRIPTION
Updated the Jekyll theme version (3.9.4) - fix for bootstrap-sass vuln